### PR TITLE
Add user registration page with form and styling

### DIFF
--- a/src/app/register/userRegister.tsx
+++ b/src/app/register/userRegister.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import React, { useState } from 'react';
+
+
+export default function UserRegister() {
+  
+  const [formData, setFormData] = useState({
+    name: '',
+    lastname: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    // Handle registration logic here
+    console.log('Form submitted:', formData);
+    // Add API call or authentication logic as needed
+  };
+
+  return (
+    <div className="bg-[#0f1124] min-h-screen text-white p-6">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-2xl font-bold mb-8">User Register</h1>
+        
+        <form onSubmit={handleSubmit} className="space-y-8">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            <div className="space-y-2">
+              <label htmlFor="name" className="block text-purple-400">
+                Name
+              </label>
+              <input
+                type="text"
+                id="name"
+                name="name"
+                value={formData.name}
+                onChange={handleChange}
+                required
+                placeholder="Name"
+                className="w-full bg-[#1a1c35] border border-gray-700 rounded-md px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500"
+              />
+            </div>
+            
+            <div className="space-y-2">
+              <label htmlFor="lastname" className="block text-purple-400">
+                Lastname
+              </label>
+              <input
+                type="text"
+                id="lastname"
+                name="lastname"
+                value={formData.lastname}
+                onChange={handleChange}
+                required
+                placeholder="Lastname"
+                className="w-full bg-[#1a1c35] border border-gray-700 rounded-md px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500"
+              />
+            </div>
+          </div>
+          
+          <div className="space-y-2">
+            <label htmlFor="email" className="block text-purple-400">
+              Email
+            </label>
+            <input
+              type="email"
+              id="email"
+              name="email"
+              value={formData.email}
+              onChange={handleChange}
+              required
+              placeholder="Email"
+              className="w-full bg-[#1a1c35] border border-gray-700 rounded-md px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500"
+            />
+          </div>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            <div className="space-y-2">
+              <label htmlFor="password" className="block text-purple-400">
+                Password
+              </label>
+              <input
+                type="password"
+                id="password"
+                name="password"
+                value={formData.password}
+                onChange={handleChange}
+                required
+                placeholder="Password"
+                className="w-full bg-[#1a1c35] border border-gray-700 rounded-md px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500"
+              />
+            </div>
+            
+            <div className="space-y-2">
+              <label htmlFor="confirmPassword" className="block text-purple-400">
+                Confirm Password
+              </label>
+              <input
+                type="password"
+                id="confirmPassword"
+                name="confirmPassword"
+                value={formData.confirmPassword}
+                onChange={handleChange}
+                required
+                placeholder="Confirm Password"
+                className="w-full bg-[#1a1c35] border border-gray-700 rounded-md px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500"
+              />
+            </div>
+          </div>
+          
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="bg-purple-600 hover:bg-purple-700 text-white font-medium py-2 px-8 rounded-md transition-colors duration-300"
+            >
+              Register
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+

--- a/src/app/register/userRegister/page.tsx
+++ b/src/app/register/userRegister/page.tsx
@@ -1,0 +1,5 @@
+import UserRegister from '../userRegister';
+
+export default function UserRegisterPage() {
+  return <UserRegister />;
+}


### PR DESCRIPTION
# User Registration Page

## Description
Added a user registration page with form validation and styling.

## Features
- Form with fields for name, lastname, email, password and confirm password
- Dark theme with purple accents
- Responsive layout
- Next.js routing support

## How to View the Page
This page can be accessed at: `/register/userRegister`

To view the page:
1. Run the development server with `npm run dev`
2. Navigate to http://localhost:3000/register/userRegister in your browser

## Testing Done
- Tested form validation
- Verified responsive layout on different screen sizes
- Verified the route is accessible

![Screenshot 2025-05-26 181014](https://github.com/user-attachments/assets/69607d15-e4e1-4d2e-9d20-8f97c541a938)


![Screenshot 2025-05-26 180957](https://github.com/user-attachments/assets/d63519c5-734a-4507-82b1-23913bb43a44)
