### PR TITLE
feat: add reusable Button component with variants and accessibility 

### DIFF
--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+
+interface ButtonProps {
+  children: React.ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+  variant?: "primary" | "secondary" | "outline";
+  size?: "small" | "medium" | "large";
+  className?: string;
+}
+
+const Button: React.FC<ButtonProps> = ({
+  children,
+  onClick,
+  disabled = false,
+  variant = "primary",
+  size = "medium",
+  className = "",
+}) => {
+  const baseClasses =
+    "inline-flex items-center justify-center font-medium rounded-full px-12 py-2 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed";
+
+  const variantClasses = {
+    primary: "bg-pink-800 text-white hover:bg-pink-900 focus:ring-pink-500",
+    secondary: "bg-gray-600 text-white hover:bg-gray-700 focus:ring-gray-500",
+    outline:
+      "border-2 border-pink-800 text-pink-800 hover:bg-pink-50 focus:ring-pink-500",
+  };
+
+  const sizeClasses = {
+    small: "px-3 py-1.5 text-sm",
+    medium: "px-4 py-2 text-base",
+    large: "px-6 py-3 text-lg",
+  };
+
+  const classes =
+    `${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${className}`.trim();
+
+  return (
+    <button
+      className={classes}
+      onClick={onClick}
+      disabled={disabled}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
# Feature Summary
Implements a reusable Button component in src/components/button.tsx based on the provided Figma design.

What's Included

✅ New file: src/components/button.tsx

✅ Supports multiple variants (primary, secondary, outline)

✅ Three sizes: small, medium, large

✅ Disabled state

✅ Custom color: #9D174D

✅ Pill-shaped design

✅ Accessible focus and keyboard navigation

✅ Tailwind CSS styling

Usage Example
```bash
import Button from '@/components/button';

<Button variant="primary" size="medium">Button</Button>
```

#ScreenShot

![image](https://github.com/user-attachments/assets/c695c1b7-49ac-4191-9be1-eeb9cdca3376)

Notes
✅Followed the Figma reference
✅No other files were created

✅ Ready for feedback