### PR TITLE
Feature/create module  modal

### DIFF
--- a/src/app/coursesPage/components/createModule.tsx
+++ b/src/app/coursesPage/components/createModule.tsx
@@ -48,7 +48,7 @@ export default function CreateModule({
       </DialogTrigger>
       <DialogContent className="sm:max-w-[500px] bg-[#0f111a] border-none">
         <DialogHeader>
-          <DialogTitle className="text-3xl font-bold text-purple-500">
+          <DialogTitle className="text-3xl font-bold text-purple-600">
             Add New Module
           </DialogTitle>
         </DialogHeader>
@@ -62,19 +62,19 @@ export default function CreateModule({
               placeholder="Title"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              className="bg-[#2a2d3d] border-[#3a3d4d] w-full text-white h-12 sm:h-14 text-base sm:text-lg rounded-full px-6 py-4 placeholder:text-gray-400 placeholder:text-sm focus:outline-none focus:border-2 focus:border-purple-400  focus:ring-2 focus:ring-purple-400"
+              className="bg-[#2a2d3d] border-2 border-purple-600 w-full text-white h-10 sm:h-12 text-base sm:text-lg rounded-full px-6 py-4 placeholder:text-gray-400 placeholder:text-sm focus:outline-none focus:border-x-4 focus:border-y-4 focus:border-purple-800  focus:ring-2 focus:ring-purple-800"
             />
           </div>
           <div className="space-y-2">
             <label htmlFor="description" className="text-white text-lg">
               Description
             </label>
-            <textarea
+            <Input
               id="description"
               placeholder="Description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              className="bg-[#2a2d3d] border-[#3a3d4d] w-full text-white h-12 sm:h-14 text-base sm:text-lg rounded-full px-6 py-4 placeholder:text-gray-400 placeholder:text-sm focus:outline-none focus:border-2 focus:border-purple-400  focus:ring-2 focus:ring-purple-400 overflow-hidden resize-none"
+              className="bg-[#2a2d3d] border-2 border-purple-600 w-full text-white h-10 sm:h-12 text-base sm:text-lg rounded-full px-6 py-4 placeholder:text-gray-400 placeholder:text-sm focus:outline-none focus:border-x-4 focus:border-y-4 focus:border-purple-800  focus:ring-2 focus:ring-purple-800"
             />
           </div>
         </div>
@@ -82,13 +82,13 @@ export default function CreateModule({
           <Button
             variant="outline"
             onClick={handleCancel}
-            className="bg-[#c93b5a] hover:bg-[#a82e4a] text-white border-none  rounded-full"
+            className="bg-[#c93b5a] hover:bg-[#a82e4a] text-white hover:text-white border-none  rounded-full"
           >
             Cancel
           </Button>
           <Button
             onClick={handleSubmit}
-            className="bg-purple-400 hover:bg-purple-400 text-white border-none rounded-full"
+            className="bg-purple-700 hover:bg-purple-600 text-white border-none rounded-full"
           >
             Create Module
           </Button>

--- a/src/app/coursesPage/components/createModule.tsx
+++ b/src/app/coursesPage/components/createModule.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import type React from "react";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+interface CreateModuleProps {
+  onCreateModule?: (moduleData: { title: string; description: string }) => void;
+  trigger?: React.ReactNode;
+}
+
+export default function CreateModule({
+  onCreateModule,
+  trigger,
+}: CreateModuleProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [open, setOpen] = useState(false);
+
+  const handleSubmit = () => {
+    if (onCreateModule) {
+      onCreateModule({ title, description });
+    }
+    setTitle("");
+    setDescription("");
+    setOpen(false);
+  };
+
+  const handleCancel = () => {
+    setTitle("");
+    setDescription("");
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger || <Button variant="outline">Create Module</Button>}
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[500px] bg-[#0f111a] border-none">
+        <DialogHeader>
+          <DialogTitle className="text-3xl font-bold text-purple-500">
+            Add New Module
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-6 py-4">
+          <div className="space-y-2">
+            <label htmlFor="title" className="text-white text-lg">
+              Module Title
+            </label>
+            <Input
+              id="title"
+              placeholder="Title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="bg-[#2a2d3d] border-[#3a3d4d] w-full text-white h-12 sm:h-14 text-base sm:text-lg rounded-full px-6 py-4 placeholder:text-gray-400 placeholder:text-sm focus:outline-none focus:border-2 focus:border-purple-400  focus:ring-2 focus:ring-purple-400"
+            />
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="description" className="text-white text-lg">
+              Description
+            </label>
+            <textarea
+              id="description"
+              placeholder="Description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="bg-[#2a2d3d] border-[#3a3d4d] w-full text-white h-12 sm:h-14 text-base sm:text-lg rounded-full px-6 py-4 placeholder:text-gray-400 placeholder:text-sm focus:outline-none focus:border-2 focus:border-purple-400  focus:ring-2 focus:ring-purple-400 overflow-hidden resize-none"
+            />
+          </div>
+        </div>
+        <div className="flex justify-end gap-3 mt-4">
+          <Button
+            variant="outline"
+            onClick={handleCancel}
+            className="bg-[#c93b5a] hover:bg-[#a82e4a] text-white border-none  rounded-full"
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            className="bg-purple-400 hover:bg-purple-400 text-white border-none rounded-full"
+          >
+            Create Module
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+
+
+

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};


### PR DESCRIPTION
# 🔃 Pull Request – Create Module Modal
Closes Issue: #22

📌 Create a Module Modal for the project at app/coursesPage/components/createModule.tsx

## ✅ What’s Done
This PR implements the CreateModule modal component as requested.
It is located at:

```bash
app/coursesPage/components/createModule.tsx
```
## Component Highlights:
Uses a custom dialog.tsx abstraction to wrap @radix-ui/react-dialog with standardized styling.

### Inputs for:

Module Title

Module Description

### Props:

onCreateModule: optional callback to return the module data

trigger: optional trigger element

Styled with the project’s dark theme and purple accents

## 🧱 Shared Component Added
Created @/components/ui/dialog.tsx to centralize and customize dialog behavior and styles using:

Dialog, DialogTrigger, DialogContent, DialogOverlay, etc.

Built with @radix-ui/react-dialog and styled via cn() utility

This ensures consistent modal behavior and design across the app.

⚠️ Notes
✔ No extra files created outside the requested scope

### Screenshots
![image](https://github.com/user-attachments/assets/ac6a4edc-7c65-4f12-96bb-48c52210af86)

### Video
[recording (2).webm](https://github.com/user-attachments/assets/133c112c-51f6-4036-8ca7-163b2f9a2362)
