### PR TITLE
feat: create instructor main page (courses)

### DIFF
--- a/src/app/instructor/components/courses.tsx
+++ b/src/app/instructor/components/courses.tsx
@@ -1,3 +1,150 @@
-export default function Courses() {
-    
+import { Button } from "@/components/ui/button";
+import { CirclePlus } from "lucide-react";
+import React, { useCallback } from "react";
+import Image from "next/image";
+
+// TypeScript Interfaces as per specification
+interface Course {
+  id: string;
+  title: string;
+  description: string;
+  thumbnail?: string;
+  studentsCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+  status: "draft" | "published" | "archived";
 }
+
+interface CoursesProps {
+  courses?: Course[];
+  isLoading?: boolean;
+  onCreateCourse: () => void | Promise<void>;
+  className?: string;
+}
+
+const Courses: React.FC<CoursesProps> = ({
+  courses = [],
+  isLoading = false,
+  onCreateCourse,
+  className = "",
+}) => {
+  const handleCreateCourse = useCallback(() => {
+    onCreateCourse();
+  }, [onCreateCourse]);
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <main className="min-h-screen flex items-center justify-center px-4 sm:px-6 lg:px-8 bg-[#0f0a15]">
+        <p className="text-white">Loading courses...</p>
+      </main>
+    );
+  }
+
+  // Empty state component
+  const EmptyState = () => (
+    <div className="rounded-lg border bg-[#111827] border-[#1F2937]">
+      <div className="flex flex-col items-center justify-center py-16 lg:py-24 px-4 text-center">
+        {/* Book icon */}
+        <div className="mb-6">
+          <Image
+            src="/openbookgrey.svg"
+            alt="No courses created yet"
+            width={60}
+            height={60}
+            className="w-16 h-16"
+          />
+        </div>
+
+        {/* Empty state text */}
+        <h3 className="mb-2 text-lg font-semibold">No courses created</h3>
+        <p className="mb-6 text-center text-[#D1D5DB]">
+          Share your expertise with the world by creating your first course
+        </p>
+
+        {/* Create course button */}
+        <Button
+          variant="default"
+          className="bg-purple-600 rounded-lg hover:bg-purple-700"
+        >
+          <CirclePlus className="h-4 w-4 mr-2" />
+          Create Course
+        </Button>
+      </div>
+    </div>
+  );
+
+  // Course card component for when courses exist
+  const CourseCard: React.FC<{ course: Course }> = ({ course }) => (
+    <div className="rounded-lg p-6 transition-all duration-200 hover:shadow-lg cursor-pointer border bg-[#1a1a2e] border-[#374151]">
+      {/* Course thumbnail placeholder */}
+      <div className="w-full h-32 rounded-md mb-4 flex items-center justify-center bg-[#374151]">
+        <svg
+          width="40"
+          height="40"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1"
+          className="text-[#a1a1aa]"
+        >
+          <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+          <circle cx="8.5" cy="8.5" r="1.5" />
+          <polyline points="21,15 16,10 5,21" />
+        </svg>
+      </div>
+
+      {/* Course details */}
+      <h3 className="text-lg font-semibold mb-2 text-white">{course.title}</h3>
+      <p className="text-sm mb-3 line-clamp-2 text-[#a1a1aa]">
+        {course.description}
+      </p>
+
+      {/* Course stats */}
+      <div className="flex items-center justify-between text-sm text-[#71717a]">
+        <span>{course.studentsCount} students</span>
+        <span>{new Date(course.createdAt).toLocaleDateString()}</span>
+      </div>
+    </div>
+  );
+
+  return (
+    <main
+      className={`min-h-screen px-4 sm:px-6 lg:px-8 bg-[#0f0a15] ${className}`}
+    >
+      {/* Content Wrapper */}
+      <div className="max-w-7xl mx-auto py-8 lg:py-12">
+        {/* Header section */}
+        <header className="flex items-center justify-between">
+          <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-white">
+            My courses
+          </h1>
+
+          {/* Header Action Button */}
+          <Button
+            variant="default"
+            className="bg-purple-600 rounded-lg hover:bg-purple-700"
+          >
+            <CirclePlus className="h-4 w-4 mr-2" />
+            Create Course
+          </Button>
+        </header>
+
+        <div className="border-b my-8 border-[#374151]"></div>
+
+        {/* Content area */}
+        {courses.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            {courses.map((course) => (
+              <CourseCard key={course.id} course={course} />
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+};
+
+export default Courses;


### PR DESCRIPTION
This pull request introduces a redesigned "My Courses" page for instructors, focusing on an improved empty state experience and consistent UI styling.

Fixes #81 

Key updates include:
- A new, visually engaging empty state has been implemented for when an instructor has not yet created any courses.
- The page's styling, including colors, fonts, and component layout, has been updated to align with the design of the instructor dashboard, ensuring a cohesive user experience.
- The "Create Course" button is now persistently displayed in the header, providing a clear and consistent call-to-action.

![Instructor courses page](https://res.cloudinary.com/dv765kdgq/image/upload/v1753939334/Screenshot_From_2025-07-31_08-21-21_h5puzf.png)