### PR TITLE
feat: add removeModule.ts file

### DIFF
--- a/src/contract_connections/CourseRegistry/removeModule.ts
+++ b/src/contract_connections/CourseRegistry/removeModule.ts
@@ -1,0 +1,58 @@
+import { useState, useCallback } from "react";
+
+interface RemoveModuleResponse {
+  success: boolean;
+  error?: string;
+}
+
+export async function removeModule(module_id: string): Promise<RemoveModuleResponse> {
+  if (!module_id.trim()) {
+    return { success: false, error: "Module ID cannot be empty" };
+  }
+
+  try {
+    const response = await simulateContractCall(module_id);
+    return response.success
+      ? { success: true }
+      : { success: false, error: response.error };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error occurred";
+    return { success: false, error: message };
+  }
+}
+
+async function simulateContractCall(module_id: string): Promise<RemoveModuleResponse> {
+  await new Promise((r) => setTimeout(r, 500));
+  if (module_id === "non_existent") {
+    return { success: false, error: "Module not found" };
+  }
+  return { success: true };
+}
+
+export function useRemoveModule() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<RemoveModuleResponse | null>(null);
+
+  const execute = useCallback(async (module_id: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await removeModule(module_id);
+      setResult(res);
+      if (!res.success) {
+        setError(res.error || "Failed to remove module");
+      }
+      return res;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error occurred";
+      setError(message);
+      setResult({ success: false, error: message });
+      return { success: false, error: message };
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { execute, isLoading, error, result };
+}


### PR DESCRIPTION
# 🚀 Pull Request  

## 🔗 Closes #116 

## 📋 Description  
This PR implements the frontend integration for removing a module by its ID, as requested in the smart contract integration issue for `course_registry_remove_module` in the CourseRegistry contract.

- Added `removeModule.ts` in `contract_connections/CourseRegistry/` to provide a typed, reusable function and React hook for removing modules by ID.
- The React hook (`useRemoveModule`) manages loading, error, and result states for UI feedback.
- The contract call is currently simulated and should be replaced with the actual contract interaction logic.
- All error and success responses follow the contract's expected output structure.

## 📂 Screenshots  
<img width="2738" height="1164" alt="skillcert-frontend" src="https://github.com/user-attachments/assets/d6ba708e-4ebc-4eb7-89ae-ffe80b91410c" />


## 🔍 Additional Notes  
- The contract call is simulated for now; replace `simulateContractCall` with the real contract call when available.
- No new dependencies or migrations introduced.
- Ensure UI components use the provided hook for proper loading and error handling.

