### PR TITLE
feat: integrate getModuleByCourse smart contract function

### DIFF
--- a/src/contract_connections/CourseRegistry/getModuleByCourse.ts
+++ b/src/contract_connections/CourseRegistry/getModuleByCourse.ts
@@ -1,0 +1,96 @@
+import { useState, useCallback } from "react";
+
+interface Module {
+  id: string;
+  course_id: string;
+  position: number;
+  title: string;
+  created_at: number;
+}
+
+interface GetModuleByCourseResponse {
+  success: boolean;
+  course_id?: string;
+  modules?: Module[];
+  error?: string;
+}
+
+export async function getModuleByCourse(
+  courseId: string
+): Promise<GetModuleByCourseResponse> {
+  if (!courseId.trim()) {
+    return {
+      success: false,
+      error: "Course ID cannot be empty.",
+    };
+  }
+  try {
+    const modules = await simulateContractCall(courseId);
+    return {
+      success: true,
+      course_id: courseId,
+      modules,
+    };
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Unknown error occurred";
+    return {
+      success: false,
+      error: message,
+    };
+  }
+}
+
+async function simulateContractCall(courseId: string): Promise<Module[]> {
+  await new Promise((r) => setTimeout(r, 800));
+
+  if (courseId === "non_existent") {
+    return [];
+  }
+
+  return [
+    {
+      id: "module-001",
+      course_id: courseId,
+      position: 1,
+      title: "Introduction to the Course",
+      created_at: Date.now(),
+    },
+    {
+      id: "module-002",
+      course_id: courseId,
+      position: 2,
+      title: "Advanced Topics",
+      created_at: Date.now(),
+    },
+  ];
+}
+
+export function useGetModuleByCourse() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<GetModuleByCourseResponse | null>(null);
+
+  const execute = useCallback(async (courseId: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await getModuleByCourse(courseId);
+      setResult(response);
+      if (!response.success) {
+        setError(response.error || "Failed to retrieve modules.");
+      }
+      return response.modules;
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Unknown error occurred";
+      setError(message);
+      setResult({ success: false, error: message });
+      return { success: false, error: message };
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { loading, error, result, execute };
+}


### PR DESCRIPTION
# 🚀 Pull Request  

## 🔗 Close #issue 113

## 📋 Description  
This PR integrates the getModuleByCourse  method from the CourseRegistry smart contract with the frontend. It includes:

- [ ]  A getModuleByCourse function in contract_connections/CourseRegistry to fetch a module by course_id.

- [ ]  A useGetModuleByCourse hook to handle loading, error, and success states.

- [ ]  Error handling for empty or invalid course_id, and user feedback when no module exists.

## 📂 Screenshots  
Add screenshots or screen recordings that visually demonstrate the changes.
<img width="1356" height="1926" alt="snap 1" src="https://github.com/user-attachments/assets/f9890e4c-5f56-4c98-87fb-17b9962bd4ee" />
<img width="1526" height="2306" alt="snap 2" src="https://github.com/user-attachments/assets/2b5955c7-cd50-44c2-b524-b5040814808f" />


## 🔍 Additional Notes  

- The current implementation uses a mocked simulated contract call for test purposes. Be sure to replace this with the actual on-chain function in prod.

- No new dependencies introduced. 