### PR TITLE
feat: the delete confirm modal

### DIFF
--- a/src/app/instructor/components/deleteConfirmModal.tsx
+++ b/src/app/instructor/components/deleteConfirmModal.tsx
@@ -1,1 +1,36 @@
-export default function DeleteConfirmModal() {}
+interface DeleteConfirmModalProps {
+  modalTitle?: string;
+  modalText?: string;
+  setIsModalOpen: (val: boolean) => void;
+}
+
+export default function DeleteConfirmModal({
+  modalTitle = "Modal title",
+  modalText = "Modal text",
+  setIsModalOpen,
+}: DeleteConfirmModalProps) {
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-black/50 z-50"
+      onClick={() => setIsModalOpen(false)}
+    >
+      <div
+        className="relative flex flex-col items-start justify-center p-6 bg-gray-950 rounded-xl shadow-lg w-[90%] md:w-[70%] xl:w-[40%] text-white font-sans space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="border-b border-gray-400 w-full py-2 space-y-2">
+          <p className="text-3xl font-medium font-poppins">{modalTitle}</p>
+          <p>{modalText}</p>
+        </div>
+        <div className="w-full flex items-end justify-end space-x-6">
+          <button className="border border-gray-400 text-gray-400 rounded-lg px-3 py-1">
+            Cancel
+          </button>
+          <button className="bg-purple-600 rounded-lg px-3 py-1">
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 🚀 Pull Request  

## 🔗 Close #149 

## 📋 Description  
- I built the delete confirm modal according the figma design provided. I followed the instructions provided. I put all my code in `app/instructor/components/deleteConfirmModal.tsx`    

## 📂 Screenshots  
Laptop Screen
<img width="738" height="299" alt="image" src="https://github.com/user-attachments/assets/9f29362b-4543-4f57-be91-9371139fdb03" />

Tablet Screen 
<img width="884" height="1104" alt="Galaxy-Tab-S7-884x1104" src="https://github.com/user-attachments/assets/15e3e079-6d1e-4df2-8502-7c9e97329c2e" />

Mobile Screen 
<img width="393" height="852" alt="iPhone-14-Pro-393x852" src="https://github.com/user-attachments/assets/eb5c6a0b-5140-41ba-9bb4-f41b8c14c1f9" />


@Jeffrey0522  
Please review 🙏 