### PR TITLE
Fix size of header when scrolled

### DIFF
--- a/src/components/nabvarMenu.tsx
+++ b/src/components/nabvarMenu.tsx
@@ -224,8 +224,11 @@ export default function NavbarMenu({
   if (path === "/") {
     return (
       <div
-        className={`fixed top-0 z-[1000] py-[40px] w-full flex items-center justify-center transition-all duration-300 ${
-          scrolled ? "bg-white/10 backdrop-blur-lg py-[20px]" : "bg-transparent"
+        className={`fixed top-0 z-[1000] py-[40px] w-full flex items-center justify-center 
+          transition-all duration-300 
+          ${scrolled ? 
+            "bg-gray-950/10 backdrop-blur-lg py-[2px]" : 
+            "bg-transparent"
         }`}
       >
         <nav className="flex justify-between items-center min-w-[1200px] ">


### PR DESCRIPTION
# 🚀 Pull Request  

## 🔗 Close #241 

## 📋 Description  
The PR updates the high padding that was defined in the header when the page scrolls down

## 📂 Screenshots  
<img width="1892" height="194" alt="image" src="https://github.com/user-attachments/assets/8beae532-7f76-4412-b29c-a32ef1cbec25" />
<img width="1884" height="113" alt="image" src="https://github.com/user-attachments/assets/3adb62f7-da79-4942-81d4-d11110fb63d2" />


## 🔍 Additional Notes  
- The connection from this header is unavailable
